### PR TITLE
Modernized for not requiring URIJS anymore => reduces effect on bundle size

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         run: npm version --no-git-tag-version ${{steps.gitversion.outputs.nuGetVersion}}
 
       # Build
-      - run: npm install
+      - run: npm ci
       - run: npm run build
       - run: npm run test
       - run: npm run docs

--- a/endpoints/Endpoint.ts
+++ b/endpoints/Endpoint.ts
@@ -1,9 +1,8 @@
+import template from 'url-template';
 import { HttpMethod, HttpHeader, HttpClient } from "../http";
 import { Serializer } from "../serializers";
 import { ErrorHandler, NotFoundError } from "../errors";
 import { LinkExtractor, Link } from "../links";
-import URI from "urijs";
-import "urijs/src/URITemplate";
 
 export class Endpoint {
     /**
@@ -201,7 +200,8 @@ export class Endpoint {
      * @throws {@link NotFoundError}: No link template with the specified `rel` could be found.
      */
     linkTemplate(rel: string, variables: { [key: string]: any; }): URL {
-        return this.join(URI.expand!(this.getLinkTemplate(rel), variables).toString());
+        const tmpl = template.parse(this.getLinkTemplate(rel))
+        return new URL(this.join(tmpl.expand(variables)))
     }
 
     /**

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,17 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+  preset: 'ts-jest/presets/default-esm',
+  // jsdom is required for Blob() constructor!
+  testEnvironment: 'jsdom',
+  testMatch: [
+    "**/?(*.)+(spec|test).ts"
+  ],
+  transform: {
+    './node_modules/url-template/lib/*.js': [
+      'ts-jest',
+      {
+        useESM: true,
+      },
+    ],
+  },
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,17 +1,12 @@
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
-  preset: 'ts-jest/presets/default-esm',
-  // jsdom is required for Blob() constructor!
+  preset: 'ts-jest',
+  // jsdom is required for Blob() constructor and fetch()!
   testEnvironment: 'jsdom',
   testMatch: [
     "**/?(*.)+(spec|test).ts"
   ],
   transform: {
-    './node_modules/url-template/lib/*.js': [
-      'ts-jest',
-      {
-        useESM: true,
-      },
-    ],
+    "\\.ts$": "ts-jest"
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,14 +12,14 @@
         "url-template": "^2.0.8"
       },
       "devDependencies": {
-        "@types/jest": "^29.0.2",
-        "@types/url-template": "^2.0.28",
-        "jest": "^29.0.3",
-        "jest-environment-jsdom": "^29.0.3",
-        "jest-fetch-mock": "^3.0.3",
-        "ts-jest": "^29.0.1",
-        "typedoc": "^0.23.14",
-        "typescript": "^4.8.3"
+        "@types/jest": "29.0.2",
+        "@types/url-template": "2.0.28",
+        "jest": "29.0.3",
+        "jest-environment-jsdom": "29.0.3",
+        "jest-fetch-mock": "3.0.3",
+        "ts-jest": "29.0.1",
+        "typedoc": "0.23.14",
+        "typescript": "4.8.3"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1080,9 +1080,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.7.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.17.tgz",
-      "integrity": "sha512-0UyfUnt02zIuqp7yC8RYtDkp/vo8bFaQ13KkSEvUAohPOAlnVNbj5Fi3fgPSuwzakS+EvvnnZ4x9y7i6ASaSPQ==",
+      "version": "18.7.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
+      "integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -1720,9 +1720,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.248",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.248.tgz",
-      "integrity": "sha512-qShjzEYpa57NnhbW2K+g+Fl+eNoDvQ7I+2MRwWnU6Z6F0HhXekzsECCLv+y2OJUsRodjqoSfwHkIX42VUFtUzg==",
+      "version": "1.4.249",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.249.tgz",
+      "integrity": "sha512-GMCxR3p2HQvIw47A599crTKYZprqihoBL4lDSAUmr7IYekXFK5t/WgEBrGJDCa2HWIZFQEkGuMqPCi05ceYqPQ==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -5220,9 +5220,9 @@
       }
     },
     "@types/node": {
-      "version": "18.7.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.17.tgz",
-      "integrity": "sha512-0UyfUnt02zIuqp7yC8RYtDkp/vo8bFaQ13KkSEvUAohPOAlnVNbj5Fi3fgPSuwzakS+EvvnnZ4x9y7i6ASaSPQ==",
+      "version": "18.7.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
+      "integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
       "dev": true
     },
     "@types/prettier": {
@@ -5718,9 +5718,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.248",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.248.tgz",
-      "integrity": "sha512-qShjzEYpa57NnhbW2K+g+Fl+eNoDvQ7I+2MRwWnU6Z6F0HhXekzsECCLv+y2OJUsRodjqoSfwHkIX42VUFtUzg==",
+      "version": "1.4.249",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.249.tgz",
+      "integrity": "sha512-GMCxR3p2HQvIw47A599crTKYZprqihoBL4lDSAUmr7IYekXFK5t/WgEBrGJDCa2HWIZFQEkGuMqPCi05ceYqPQ==",
       "dev": true
     },
     "emittery": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,17 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@types/urijs": "^1.19.19",
-        "urijs": "^1.19.11"
+        "url-template": "^2.0.8"
       },
       "devDependencies": {
-        "@types/jest": "29.0.1",
-        "jest": "29.0.3",
-        "jest-environment-jsdom": "29.0.3",
-        "jest-fetch-mock": "3.0.3",
-        "ts-jest": "29.0.0",
-        "typedoc": "0.23.11",
-        "typescript": "4.8.3"
+        "@types/jest": "^29.0.2",
+        "@types/url-template": "^2.0.28",
+        "jest": "^29.0.3",
+        "jest-environment-jsdom": "^29.0.3",
+        "jest-fetch-mock": "^3.0.3",
+        "ts-jest": "^29.0.1",
+        "typedoc": "^0.23.14",
+        "typescript": "^4.8.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -48,30 +48,30 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.18.13",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.13.tgz",
-      "integrity": "sha512-5yUzC5LqyTFp2HLmDoxGQelcdYgSpP9xsnMWBphAscOdFrHSAVbLNzWiy32sVNDqJRDiJK6klfDnAgu6PAGSHw==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.0.tgz",
+      "integrity": "sha512-y5rqgTTPTmaF5e2nVhOxw+Ur9HDJLsWb6U/KpgUzRZEdPfE6VOubXBKLdbcUTijzRptednSBDQbYZBOSqJxpJw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.18.13",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.13.tgz",
-      "integrity": "sha512-ZisbOvRRusFktksHSG6pjj1CSvkPkcZq/KHD45LAkVP/oiHJkNBZWfpvlLmX8OtHDG8IuzsFlVRWo08w7Qxn0A==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.0.tgz",
+      "integrity": "sha512-reM4+U7B9ss148rh2n1Qs9ASS+w94irYXga7c2jaQv9RVzpS7Mv1a9rnYYwuDa45G+DkORt9g6An2k/V4d9LbQ==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.18.13",
-        "@babel/helper-compilation-targets": "^7.18.9",
-        "@babel/helper-module-transforms": "^7.18.9",
-        "@babel/helpers": "^7.18.9",
-        "@babel/parser": "^7.18.13",
+        "@babel/generator": "^7.19.0",
+        "@babel/helper-compilation-targets": "^7.19.0",
+        "@babel/helper-module-transforms": "^7.19.0",
+        "@babel/helpers": "^7.19.0",
+        "@babel/parser": "^7.19.0",
         "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.18.13",
-        "@babel/types": "^7.18.13",
+        "@babel/traverse": "^7.19.0",
+        "@babel/types": "^7.19.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -87,12 +87,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.18.13",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.13.tgz",
-      "integrity": "sha512-CkPg8ySSPuHTYPJYo7IRALdqyjM9HCbt/3uOBEFbzyGVP6Mn8bwFPB0jX6982JVNBlYzM1nnPkfjuXSOPtQeEQ==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.0.tgz",
+      "integrity": "sha512-S1ahxf1gZ2dpoiFgA+ohK9DIpz50bJ0CWs7Zlzb54Z4sG8qmdIrGrVqmy1sAtTVRb+9CU6U8VqT9L0Zj7hxHVg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.18.13",
+        "@babel/types": "^7.19.0",
         "@jridgewell/gen-mapping": "^0.3.2",
         "jsesc": "^2.5.1"
       },
@@ -115,12 +115,12 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz",
-      "integrity": "sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.0.tgz",
+      "integrity": "sha512-Ai5bNWXIvwDvWM7njqsG3feMlL9hCVQsPYXodsZyLwshYkZVJt59Gftau4VrE8S9IT9asd2uSP1hG6wCNw+sXA==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.18.8",
+        "@babel/compat-data": "^7.19.0",
         "@babel/helper-validator-option": "^7.18.6",
         "browserslist": "^4.20.2",
         "semver": "^6.3.0"
@@ -142,13 +142,13 @@
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz",
-      "integrity": "sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
+      "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.18.6",
-        "@babel/types": "^7.18.9"
+        "@babel/template": "^7.18.10",
+        "@babel/types": "^7.19.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -179,9 +179,9 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz",
-      "integrity": "sha512-KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.19.0.tgz",
+      "integrity": "sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.18.9",
@@ -189,18 +189,18 @@
         "@babel/helper-simple-access": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
         "@babel/helper-validator-identifier": "^7.18.6",
-        "@babel/template": "^7.18.6",
-        "@babel/traverse": "^7.18.9",
-        "@babel/types": "^7.18.9"
+        "@babel/template": "^7.18.10",
+        "@babel/traverse": "^7.19.0",
+        "@babel/types": "^7.19.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.9.tgz",
-      "integrity": "sha512-aBXPT3bmtLryXaoJLyYPXPlSD4p1ld9aYeR+sJNOZjJJGiOpb+fKfh3NkcCu7J54nUJwCERPBExCCpyCOHnu/w==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
+      "integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -258,14 +258,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.9.tgz",
-      "integrity": "sha512-Jf5a+rbrLoR4eNdUmnFu8cN5eNJT6qdTdOg5IHIzq87WwyRw9PwguLFOWYgktN/60IP4fgDUawJvs7PjQIzELQ==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.19.0.tgz",
+      "integrity": "sha512-DRBCKGwIEdqY3+rPJgG/dKfQy9+08rHIAJx8q2p+HSWP87s2HCrQmaAMMyMll2kIXKCW0cO1RdQskx15Xakftg==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.18.6",
-        "@babel/traverse": "^7.18.9",
-        "@babel/types": "^7.18.9"
+        "@babel/template": "^7.18.10",
+        "@babel/traverse": "^7.19.0",
+        "@babel/types": "^7.19.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -357,9 +357,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.18.13",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.13.tgz",
-      "integrity": "sha512-dgXcIfMuQ0kgzLB2b9tRZs7TTFFaGM2AbtA4fJgUUYukzGH4jwsS7hzQHEGs67jdehpm22vkgKwvbU+aEflgwg==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.0.tgz",
+      "integrity": "sha512-74bEXKX2h+8rrfQUfsBfuZZHzsEs6Eql4pqy/T4Nn6Y9wNPggQOqD6z6pn5Bl8ZfysKouFZT/UXEH94ummEeQw==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -560,19 +560,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.18.13",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.13.tgz",
-      "integrity": "sha512-N6kt9X1jRMLPxxxPYWi7tgvJRH/rtoU+dbKAPDM44RFHiMH8igdsaSBgFeskhSl/kLWLDUvIh1RXCrTmg0/zvA==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.0.tgz",
+      "integrity": "sha512-4pKpFRDh+utd2mbRC8JLnlsMUii3PMHjpL6a0SZ4NMZy7YFP9aXORxEhdMVOc9CpWtDF09IkciQLEhK7Ml7gRA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.18.13",
+        "@babel/generator": "^7.19.0",
         "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-function-name": "^7.18.9",
+        "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.18.13",
-        "@babel/types": "^7.18.13",
+        "@babel/parser": "^7.19.0",
+        "@babel/types": "^7.19.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -581,9 +581,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.18.13",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.13.tgz",
-      "integrity": "sha512-ePqfTihzW0W6XAU+aMw2ykilisStJfDnsejDCXRchCcMJ4O0+8DhPXf2YUbZ6wjBlsEmZwLK/sPweWtu8hcJYQ==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.0.tgz",
+      "integrity": "sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.18.10",
@@ -952,9 +952,9 @@
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.24.28",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.28.tgz",
-      "integrity": "sha512-dgJd3HLOkLmz4Bw50eZx/zJwtBq65nms3N9VBYu5LTjJ883oBFkTyXRlCB/ZGGwqYpJJHA5zW2Ibhl5ngITfow==",
+      "version": "0.24.41",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.41.tgz",
+      "integrity": "sha512-TJCgQurls4FipFvHeC+gfAzb+GGstL0TDwYJKQVtTeSvJIznWzP7g3bAd5gEBlr8+bIxqnWS9VGVWREDhmE8jA==",
       "dev": true
     },
     "node_modules/@sinonjs/commons": {
@@ -1017,9 +1017,9 @@
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.0.tgz",
-      "integrity": "sha512-v4Vwdko+pgymgS+A2UIaJru93zQd85vIGWObM5ekZNdXCKtDYqATlEYnWgfo86Q6I1Lh0oXnksDnMU1cwmlPDw==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.1.tgz",
+      "integrity": "sha512-FSdLaZh2UxaMuLp9lixWaHq/golWTRWOnRsAXzDTDSDOQLuZb1nsdCt6pJSPWSEQt2eFZ2YVk3oYhn+1kLMeMA==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.3.0"
@@ -1059,9 +1059,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "29.0.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.0.1.tgz",
-      "integrity": "sha512-CAZrjLRZs4xEdIrfrdV74xK1Vo/BKQZwUcjJv3gp6gMeV3BsVxMnXTcgtYOKyphT4DPPo7jxVEVhuwJTQn3oPQ==",
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.0.2.tgz",
+      "integrity": "sha512-TaklkwSEtvwJpleiKBHgEBySIQlcZ08gYP/s5wdtdLnjz9uxjnDd7U+Y0JWACebkqBc+jtbol2PEtEW0wQV2zQ==",
       "dev": true,
       "dependencies": {
         "expect": "^29.0.0",
@@ -1080,9 +1080,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.7.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.13.tgz",
-      "integrity": "sha512-46yIhxSe5xEaJZXWdIBP7GU4HDTG8/eo0qd9atdiL+lFpA03y8KS+lkTN834TWJj5767GbWv4n/P6efyTFt1Dw==",
+      "version": "18.7.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.17.tgz",
+      "integrity": "sha512-0UyfUnt02zIuqp7yC8RYtDkp/vo8bFaQ13KkSEvUAohPOAlnVNbj5Fi3fgPSuwzakS+EvvnnZ4x9y7i6ASaSPQ==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -1103,15 +1103,16 @@
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
       "dev": true
     },
-    "node_modules/@types/urijs": {
-      "version": "1.19.19",
-      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.19.tgz",
-      "integrity": "sha512-FDJNkyhmKLw7uEvTxx5tSXfPeQpO0iy73Ry+PmYZJvQy0QIWX8a7kJ4kLWRf+EbTPJEPDSgPXHaM7pzr5lmvCg=="
+    "node_modules/@types/url-template": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/@types/url-template/-/url-template-2.0.28.tgz",
+      "integrity": "sha512-1i/YtOhvlWDbMDTWhCfvhyUwBS9vNFs78sJOyahoruJCcDbwaSH73AlnuCp7luKPm6qqdCg4VKq/IHUncl6gZA==",
+      "dev": true
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.11",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.11.tgz",
-      "integrity": "sha512-aB4y9UDUXTSMxmM4MH+YnuR0g5Cph3FLQBoWoMB21DSvFVAxRVEHEMx3TLh+zUZYMCQtKiqazz0Q4Rre31f/OA==",
+      "version": "17.0.12",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.12.tgz",
+      "integrity": "sha512-Nz4MPhecOFArtm81gFQvQqdV7XYCrWKx5uUt6GNHredFHn1i2mtWqXTON7EPXMtNi1qjtjEM/VCHDhcHsAMLXQ==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -1450,9 +1451,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001383",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001383.tgz",
-      "integrity": "sha512-swMpEoTp5vDoGBZsYZX7L7nXHe6dsHxi9o6/LKf/f0LukVtnrxly5GVb/fWdCDTqi/yw6Km6tiJ0pmBacm0gbg==",
+      "version": "1.0.30001399",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001399.tgz",
+      "integrity": "sha512-4vQ90tMKS+FkvuVWS5/QY1+d805ODxZiKFzsU8o/RsVJz49ZSRR8EjykLJbqhzdPgadbX6wB538wOzle3JniRA==",
       "dev": true,
       "funding": [
         {
@@ -1491,9 +1492,9 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz",
-      "integrity": "sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.4.0.tgz",
+      "integrity": "sha512-t5QdPT5jq3o262DOQ8zA6E1tlH2upmUc4Hlvrbx1pGYJuiiHl7O7rvVNI+l8HTVhd/q3Qc9vqimkNk5yiXsAug==",
       "dev": true
     },
     "node_modules/cjs-module-lexer": {
@@ -1719,9 +1720,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.232",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.232.tgz",
-      "integrity": "sha512-nd+FW8xHjM+PxNWG44nKnwHaBDdVpJUZuI2sS2JJPt/QpdombnmoCRWEEQNnzaktdIQhsNWdD+dlqxwO8Bn99g==",
+      "version": "1.4.248",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.248.tgz",
+      "integrity": "sha512-qShjzEYpa57NnhbW2K+g+Fl+eNoDvQ7I+2MRwWnU6Z6F0HhXekzsECCLv+y2OJUsRodjqoSfwHkIX42VUFtUzg==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -3004,9 +3005,9 @@
       }
     },
     "node_modules/jsonc-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.1.0.tgz",
-      "integrity": "sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true
     },
     "node_modules/kleur": {
@@ -3113,9 +3114,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.0.19",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.19.tgz",
-      "integrity": "sha512-rgQF/OxOiLcvgUAj1Q1tAf4Bgxn5h5JZTp04Fx4XUkVhs7B+7YA9JEWJhJpoO8eJt8MkZMwqLCNeNqj1bCREZQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
+      "integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA==",
       "dev": true,
       "bin": {
         "marked": "bin/marked.js"
@@ -3273,9 +3274,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.1.tgz",
-      "integrity": "sha512-JYOWTeFoS0Z93587vRJgASD5Ut11fYl5NyihP3KrYBvMe1FRRs6RN7m20SA/16GM4P6hTnZjT+UmDOt38UeXNg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.2.tgz",
+      "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==",
       "dev": true
     },
     "node_modules/once": {
@@ -3935,9 +3936,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.0.0.tgz",
-      "integrity": "sha512-OxUaigbv5Aon3OMLY9HBtwkGMs1upWE/URrmmVQFzzOcGlEPVuWzGmXUIkWGt/95Dj/T6MGuTrHHGL6kT6Yn8g==",
+      "version": "29.0.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.0.1.tgz",
+      "integrity": "sha512-htQOHshgvhn93QLxrmxpiQPk69+M1g7govO1g6kf6GsjCv4uvRV0znVmDrrvjUrVCnTYeY4FBxTYYYD4airyJA==",
       "dev": true,
       "dependencies": {
         "bs-logger": "0.x",
@@ -4026,9 +4027,9 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.23.11",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.11.tgz",
-      "integrity": "sha512-FhZ2HfqlS++53UwHk4txCsTrTlpYR0So/0osMyBeP1E7llRNRqycJGfYK1qx9Wvvv5VO8tGdpwzOwDW5FrTi7A==",
+      "version": "0.23.14",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.14.tgz",
+      "integrity": "sha512-s2I+ZKBET38EctZvbXp2GooHrNaKjWZkrwGEK/sttnOGiKJqU0vHrsdcwLgKZGuo2aedNL3RRPj1LnAAeYscig==",
       "dev": true,
       "dependencies": {
         "lunr": "^2.3.9",
@@ -4090,9 +4091,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
-      "integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.9.tgz",
+      "integrity": "sha512-/xsqn21EGVdXI3EXSum1Yckj3ZVZugqyOZQ/CxYPBD/R+ko9NSUScf8tFF4dOKY+2pvSSJA/S+5B8s4Zr4kyvg==",
       "dev": true,
       "funding": [
         {
@@ -4115,11 +4116,6 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/urijs": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
-      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ=="
-    },
     "node_modules/url-parse": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
@@ -4129,6 +4125,11 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.0.1",
@@ -4401,27 +4402,27 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.18.13",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.13.tgz",
-      "integrity": "sha512-5yUzC5LqyTFp2HLmDoxGQelcdYgSpP9xsnMWBphAscOdFrHSAVbLNzWiy32sVNDqJRDiJK6klfDnAgu6PAGSHw==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.0.tgz",
+      "integrity": "sha512-y5rqgTTPTmaF5e2nVhOxw+Ur9HDJLsWb6U/KpgUzRZEdPfE6VOubXBKLdbcUTijzRptednSBDQbYZBOSqJxpJw==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.18.13",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.13.tgz",
-      "integrity": "sha512-ZisbOvRRusFktksHSG6pjj1CSvkPkcZq/KHD45LAkVP/oiHJkNBZWfpvlLmX8OtHDG8IuzsFlVRWo08w7Qxn0A==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.0.tgz",
+      "integrity": "sha512-reM4+U7B9ss148rh2n1Qs9ASS+w94irYXga7c2jaQv9RVzpS7Mv1a9rnYYwuDa45G+DkORt9g6An2k/V4d9LbQ==",
       "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.18.13",
-        "@babel/helper-compilation-targets": "^7.18.9",
-        "@babel/helper-module-transforms": "^7.18.9",
-        "@babel/helpers": "^7.18.9",
-        "@babel/parser": "^7.18.13",
+        "@babel/generator": "^7.19.0",
+        "@babel/helper-compilation-targets": "^7.19.0",
+        "@babel/helper-module-transforms": "^7.19.0",
+        "@babel/helpers": "^7.19.0",
+        "@babel/parser": "^7.19.0",
         "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.18.13",
-        "@babel/types": "^7.18.13",
+        "@babel/traverse": "^7.19.0",
+        "@babel/types": "^7.19.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -4430,12 +4431,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.18.13",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.13.tgz",
-      "integrity": "sha512-CkPg8ySSPuHTYPJYo7IRALdqyjM9HCbt/3uOBEFbzyGVP6Mn8bwFPB0jX6982JVNBlYzM1nnPkfjuXSOPtQeEQ==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.0.tgz",
+      "integrity": "sha512-S1ahxf1gZ2dpoiFgA+ohK9DIpz50bJ0CWs7Zlzb54Z4sG8qmdIrGrVqmy1sAtTVRb+9CU6U8VqT9L0Zj7hxHVg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.18.13",
+        "@babel/types": "^7.19.0",
         "@jridgewell/gen-mapping": "^0.3.2",
         "jsesc": "^2.5.1"
       },
@@ -4454,12 +4455,12 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz",
-      "integrity": "sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.0.tgz",
+      "integrity": "sha512-Ai5bNWXIvwDvWM7njqsG3feMlL9hCVQsPYXodsZyLwshYkZVJt59Gftau4VrE8S9IT9asd2uSP1hG6wCNw+sXA==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.18.8",
+        "@babel/compat-data": "^7.19.0",
         "@babel/helper-validator-option": "^7.18.6",
         "browserslist": "^4.20.2",
         "semver": "^6.3.0"
@@ -4472,13 +4473,13 @@
       "dev": true
     },
     "@babel/helper-function-name": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz",
-      "integrity": "sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
+      "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.18.6",
-        "@babel/types": "^7.18.9"
+        "@babel/template": "^7.18.10",
+        "@babel/types": "^7.19.0"
       }
     },
     "@babel/helper-hoist-variables": {
@@ -4500,9 +4501,9 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz",
-      "integrity": "sha512-KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.19.0.tgz",
+      "integrity": "sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==",
       "dev": true,
       "requires": {
         "@babel/helper-environment-visitor": "^7.18.9",
@@ -4510,15 +4511,15 @@
         "@babel/helper-simple-access": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
         "@babel/helper-validator-identifier": "^7.18.6",
-        "@babel/template": "^7.18.6",
-        "@babel/traverse": "^7.18.9",
-        "@babel/types": "^7.18.9"
+        "@babel/template": "^7.18.10",
+        "@babel/traverse": "^7.19.0",
+        "@babel/types": "^7.19.0"
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.9.tgz",
-      "integrity": "sha512-aBXPT3bmtLryXaoJLyYPXPlSD4p1ld9aYeR+sJNOZjJJGiOpb+fKfh3NkcCu7J54nUJwCERPBExCCpyCOHnu/w==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
+      "integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==",
       "dev": true
     },
     "@babel/helper-simple-access": {
@@ -4558,14 +4559,14 @@
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.9.tgz",
-      "integrity": "sha512-Jf5a+rbrLoR4eNdUmnFu8cN5eNJT6qdTdOg5IHIzq87WwyRw9PwguLFOWYgktN/60IP4fgDUawJvs7PjQIzELQ==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.19.0.tgz",
+      "integrity": "sha512-DRBCKGwIEdqY3+rPJgG/dKfQy9+08rHIAJx8q2p+HSWP87s2HCrQmaAMMyMll2kIXKCW0cO1RdQskx15Xakftg==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.18.6",
-        "@babel/traverse": "^7.18.9",
-        "@babel/types": "^7.18.9"
+        "@babel/template": "^7.18.10",
+        "@babel/traverse": "^7.19.0",
+        "@babel/types": "^7.19.0"
       }
     },
     "@babel/highlight": {
@@ -4638,9 +4639,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.18.13",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.13.tgz",
-      "integrity": "sha512-dgXcIfMuQ0kgzLB2b9tRZs7TTFFaGM2AbtA4fJgUUYukzGH4jwsS7hzQHEGs67jdehpm22vkgKwvbU+aEflgwg==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.0.tgz",
+      "integrity": "sha512-74bEXKX2h+8rrfQUfsBfuZZHzsEs6Eql4pqy/T4Nn6Y9wNPggQOqD6z6pn5Bl8ZfysKouFZT/UXEH94ummEeQw==",
       "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
@@ -4781,27 +4782,27 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.18.13",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.13.tgz",
-      "integrity": "sha512-N6kt9X1jRMLPxxxPYWi7tgvJRH/rtoU+dbKAPDM44RFHiMH8igdsaSBgFeskhSl/kLWLDUvIh1RXCrTmg0/zvA==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.0.tgz",
+      "integrity": "sha512-4pKpFRDh+utd2mbRC8JLnlsMUii3PMHjpL6a0SZ4NMZy7YFP9aXORxEhdMVOc9CpWtDF09IkciQLEhK7Ml7gRA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.18.13",
+        "@babel/generator": "^7.19.0",
         "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-function-name": "^7.18.9",
+        "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.18.13",
-        "@babel/types": "^7.18.13",
+        "@babel/parser": "^7.19.0",
+        "@babel/types": "^7.19.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.18.13",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.13.tgz",
-      "integrity": "sha512-ePqfTihzW0W6XAU+aMw2ykilisStJfDnsejDCXRchCcMJ4O0+8DhPXf2YUbZ6wjBlsEmZwLK/sPweWtu8hcJYQ==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.0.tgz",
+      "integrity": "sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==",
       "dev": true,
       "requires": {
         "@babel/helper-string-parser": "^7.18.10",
@@ -5094,9 +5095,9 @@
       }
     },
     "@sinclair/typebox": {
-      "version": "0.24.28",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.28.tgz",
-      "integrity": "sha512-dgJd3HLOkLmz4Bw50eZx/zJwtBq65nms3N9VBYu5LTjJ883oBFkTyXRlCB/ZGGwqYpJJHA5zW2Ibhl5ngITfow==",
+      "version": "0.24.41",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.41.tgz",
+      "integrity": "sha512-TJCgQurls4FipFvHeC+gfAzb+GGstL0TDwYJKQVtTeSvJIznWzP7g3bAd5gEBlr8+bIxqnWS9VGVWREDhmE8jA==",
       "dev": true
     },
     "@sinonjs/commons": {
@@ -5156,9 +5157,9 @@
       }
     },
     "@types/babel__traverse": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.0.tgz",
-      "integrity": "sha512-v4Vwdko+pgymgS+A2UIaJru93zQd85vIGWObM5ekZNdXCKtDYqATlEYnWgfo86Q6I1Lh0oXnksDnMU1cwmlPDw==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.1.tgz",
+      "integrity": "sha512-FSdLaZh2UxaMuLp9lixWaHq/golWTRWOnRsAXzDTDSDOQLuZb1nsdCt6pJSPWSEQt2eFZ2YVk3oYhn+1kLMeMA==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
@@ -5198,9 +5199,9 @@
       }
     },
     "@types/jest": {
-      "version": "29.0.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.0.1.tgz",
-      "integrity": "sha512-CAZrjLRZs4xEdIrfrdV74xK1Vo/BKQZwUcjJv3gp6gMeV3BsVxMnXTcgtYOKyphT4DPPo7jxVEVhuwJTQn3oPQ==",
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.0.2.tgz",
+      "integrity": "sha512-TaklkwSEtvwJpleiKBHgEBySIQlcZ08gYP/s5wdtdLnjz9uxjnDd7U+Y0JWACebkqBc+jtbol2PEtEW0wQV2zQ==",
       "dev": true,
       "requires": {
         "expect": "^29.0.0",
@@ -5219,9 +5220,9 @@
       }
     },
     "@types/node": {
-      "version": "18.7.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.13.tgz",
-      "integrity": "sha512-46yIhxSe5xEaJZXWdIBP7GU4HDTG8/eo0qd9atdiL+lFpA03y8KS+lkTN834TWJj5767GbWv4n/P6efyTFt1Dw==",
+      "version": "18.7.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.17.tgz",
+      "integrity": "sha512-0UyfUnt02zIuqp7yC8RYtDkp/vo8bFaQ13KkSEvUAohPOAlnVNbj5Fi3fgPSuwzakS+EvvnnZ4x9y7i6ASaSPQ==",
       "dev": true
     },
     "@types/prettier": {
@@ -5242,15 +5243,16 @@
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
       "dev": true
     },
-    "@types/urijs": {
-      "version": "1.19.19",
-      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.19.tgz",
-      "integrity": "sha512-FDJNkyhmKLw7uEvTxx5tSXfPeQpO0iy73Ry+PmYZJvQy0QIWX8a7kJ4kLWRf+EbTPJEPDSgPXHaM7pzr5lmvCg=="
+    "@types/url-template": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/@types/url-template/-/url-template-2.0.28.tgz",
+      "integrity": "sha512-1i/YtOhvlWDbMDTWhCfvhyUwBS9vNFs78sJOyahoruJCcDbwaSH73AlnuCp7luKPm6qqdCg4VKq/IHUncl6gZA==",
+      "dev": true
     },
     "@types/yargs": {
-      "version": "17.0.11",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.11.tgz",
-      "integrity": "sha512-aB4y9UDUXTSMxmM4MH+YnuR0g5Cph3FLQBoWoMB21DSvFVAxRVEHEMx3TLh+zUZYMCQtKiqazz0Q4Rre31f/OA==",
+      "version": "17.0.12",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.12.tgz",
+      "integrity": "sha512-Nz4MPhecOFArtm81gFQvQqdV7XYCrWKx5uUt6GNHredFHn1i2mtWqXTON7EPXMtNi1qjtjEM/VCHDhcHsAMLXQ==",
       "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
@@ -5506,9 +5508,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001383",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001383.tgz",
-      "integrity": "sha512-swMpEoTp5vDoGBZsYZX7L7nXHe6dsHxi9o6/LKf/f0LukVtnrxly5GVb/fWdCDTqi/yw6Km6tiJ0pmBacm0gbg==",
+      "version": "1.0.30001399",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001399.tgz",
+      "integrity": "sha512-4vQ90tMKS+FkvuVWS5/QY1+d805ODxZiKFzsU8o/RsVJz49ZSRR8EjykLJbqhzdPgadbX6wB538wOzle3JniRA==",
       "dev": true
     },
     "chalk": {
@@ -5528,9 +5530,9 @@
       "dev": true
     },
     "ci-info": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz",
-      "integrity": "sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.4.0.tgz",
+      "integrity": "sha512-t5QdPT5jq3o262DOQ8zA6E1tlH2upmUc4Hlvrbx1pGYJuiiHl7O7rvVNI+l8HTVhd/q3Qc9vqimkNk5yiXsAug==",
       "dev": true
     },
     "cjs-module-lexer": {
@@ -5716,9 +5718,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.232",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.232.tgz",
-      "integrity": "sha512-nd+FW8xHjM+PxNWG44nKnwHaBDdVpJUZuI2sS2JJPt/QpdombnmoCRWEEQNnzaktdIQhsNWdD+dlqxwO8Bn99g==",
+      "version": "1.4.248",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.248.tgz",
+      "integrity": "sha512-qShjzEYpa57NnhbW2K+g+Fl+eNoDvQ7I+2MRwWnU6Z6F0HhXekzsECCLv+y2OJUsRodjqoSfwHkIX42VUFtUzg==",
       "dev": true
     },
     "emittery": {
@@ -6681,9 +6683,9 @@
       "dev": true
     },
     "jsonc-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.1.0.tgz",
-      "integrity": "sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true
     },
     "kleur": {
@@ -6769,9 +6771,9 @@
       }
     },
     "marked": {
-      "version": "4.0.19",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.19.tgz",
-      "integrity": "sha512-rgQF/OxOiLcvgUAj1Q1tAf4Bgxn5h5JZTp04Fx4XUkVhs7B+7YA9JEWJhJpoO8eJt8MkZMwqLCNeNqj1bCREZQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
+      "integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA==",
       "dev": true
     },
     "merge-stream": {
@@ -6893,9 +6895,9 @@
       }
     },
     "nwsapi": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.1.tgz",
-      "integrity": "sha512-JYOWTeFoS0Z93587vRJgASD5Ut11fYl5NyihP3KrYBvMe1FRRs6RN7m20SA/16GM4P6hTnZjT+UmDOt38UeXNg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.2.tgz",
+      "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==",
       "dev": true
     },
     "once": {
@@ -7391,9 +7393,9 @@
       }
     },
     "ts-jest": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.0.0.tgz",
-      "integrity": "sha512-OxUaigbv5Aon3OMLY9HBtwkGMs1upWE/URrmmVQFzzOcGlEPVuWzGmXUIkWGt/95Dj/T6MGuTrHHGL6kT6Yn8g==",
+      "version": "29.0.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.0.1.tgz",
+      "integrity": "sha512-htQOHshgvhn93QLxrmxpiQPk69+M1g7govO1g6kf6GsjCv4uvRV0znVmDrrvjUrVCnTYeY4FBxTYYYD4airyJA==",
       "dev": true,
       "requires": {
         "bs-logger": "0.x",
@@ -7439,9 +7441,9 @@
       "dev": true
     },
     "typedoc": {
-      "version": "0.23.11",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.11.tgz",
-      "integrity": "sha512-FhZ2HfqlS++53UwHk4txCsTrTlpYR0So/0osMyBeP1E7llRNRqycJGfYK1qx9Wvvv5VO8tGdpwzOwDW5FrTi7A==",
+      "version": "0.23.14",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.14.tgz",
+      "integrity": "sha512-s2I+ZKBET38EctZvbXp2GooHrNaKjWZkrwGEK/sttnOGiKJqU0vHrsdcwLgKZGuo2aedNL3RRPj1LnAAeYscig==",
       "dev": true,
       "requires": {
         "lunr": "^2.3.9",
@@ -7483,19 +7485,14 @@
       "dev": true
     },
     "update-browserslist-db": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
-      "integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.9.tgz",
+      "integrity": "sha512-/xsqn21EGVdXI3EXSum1Yckj3ZVZugqyOZQ/CxYPBD/R+ko9NSUScf8tFF4dOKY+2pvSSJA/S+5B8s4Zr4kyvg==",
       "dev": true,
       "requires": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"
       }
-    },
-    "urijs": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
-      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ=="
     },
     "url-parse": {
       "version": "1.5.10",
@@ -7506,6 +7503,11 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="
     },
     "v8-to-istanbul": {
       "version": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -24,26 +24,22 @@
   ],
   "scripts": {
     "build": "tsc",
+    "check": "tsc --noEmit",
+    "clean": "git clean -fXd",
     "test": "jest",
     "docs": "typedoc"
   },
-  "jest": {
-    "testEnvironment": "jsdom",
-    "transform": {
-      "\\.ts$": "ts-jest"
-    }
-  },
   "devDependencies": {
-    "@types/jest": "29.0.1",
-    "jest": "29.0.3",
-    "jest-environment-jsdom": "29.0.3",
-    "jest-fetch-mock": "3.0.3",
-    "ts-jest": "29.0.0",
-    "typedoc": "0.23.11",
-    "typescript": "4.8.3"
+    "@types/jest": "^29.0.2",
+    "@types/url-template": "^2.0.28",
+    "jest": "^29.0.3",
+    "jest-environment-jsdom": "^29.0.3",
+    "jest-fetch-mock": "^3.0.3",
+    "ts-jest": "^29.0.1",
+    "typedoc": "^0.23.14",
+    "typescript": "^4.8.3"
   },
   "dependencies": {
-    "@types/urijs": "^1.19.19",
-    "urijs": "^1.19.11"
+    "url-template": "^2.0.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,14 +28,14 @@
     "docs": "typedoc"
   },
   "devDependencies": {
-    "@types/jest": "^29.0.2",
-    "@types/url-template": "^2.0.28",
-    "jest": "^29.0.3",
-    "jest-environment-jsdom": "^29.0.3",
-    "jest-fetch-mock": "^3.0.3",
-    "ts-jest": "^29.0.1",
-    "typedoc": "^0.23.14",
-    "typescript": "^4.8.3"
+    "@types/jest": "29.0.2",
+    "@types/url-template": "2.0.28",
+    "jest": "29.0.3",
+    "jest-environment-jsdom": "29.0.3",
+    "jest-fetch-mock": "3.0.3",
+    "ts-jest": "29.0.1",
+    "typedoc": "0.23.14",
+    "typescript": "4.8.3"
   },
   "dependencies": {
     "url-template": "^2.0.8"

--- a/package.json
+++ b/package.json
@@ -24,8 +24,6 @@
   ],
   "scripts": {
     "build": "tsc",
-    "check": "tsc --noEmit",
-    "clean": "git clean -fXd",
     "test": "jest",
     "docs": "typedoc"
   },

--- a/renovate.json
+++ b/renovate.json
@@ -15,11 +15,6 @@
     {
       "matchPackagePatterns": ["typedoc"],
       "enabled": false
-    },
-    {
-      "matchPackagePatterns": ["urijs"],
-      "automerge": true,
-      "automergeType": "branch"
     }
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,13 +7,6 @@
     "noUnusedLocals": true,
     "strict": true
   },
-  "include": [
-    "**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "**/*.test.ts",
-  ],
   "typedocOptions": {
     "name": "TypedRest for TypeScript",
     "entryPoints": "index.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,13 @@
     "noUnusedLocals": true,
     "strict": true
   },
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/*.test.ts",
+  ],
   "typedocOptions": {
     "name": "TypedRest for TypeScript",
     "entryPoints": "index.ts",


### PR DESCRIPTION
- Removes URIJS polyfill. This is natively supported by most browsers/environments today and reduces bundle size dramatically when using this library.
- Switches to `url-template` for templating needs.
- Test suite runs fine :) 
- Minor cleanup of `tsconfig`